### PR TITLE
Enable MCU_48MHZ for Emax Lightning esc

### DIFF
--- a/SiLabs/EMAX_Lightning_20A.inc
+++ b/SiLabs/EMAX_Lightning_20A.inc
@@ -45,7 +45,7 @@ Eep_ESC_Layout:		DB	"#EMAX_Ltng_20A# "	; ESC layout tag
 CSEG AT 1A50h
 Eep_ESC_MCU:			DB	"#BLHELI#F390#   "	; Project and MCU tag (16 Bytes)
 
-MCU_48MHZ				EQU	0	; Set to 1 if MCU can run at 48MHz
+MCU_48MHZ			EQU	1	; Set to 1 if MCU can run at 48MHz
 ONE_S_CAPABLE			EQU	0	; Set to 1 if ESC can operate at 1S
 PORT3_EXIST			EQU	0	; Set to 1 if MCU has port3
 COMP1_USED			EQU	0	; Set to 1 if MCU has comparator 1 and it is being used


### PR DESCRIPTION
Emax Lightning has F390 MCU (like FVT Littlebee), so it supports 48Mhz, I have tested it (https://github.com/bitdump/BLHeli/issues/190).